### PR TITLE
Add script for generating compose files

### DIFF
--- a/.changeset/cozy-plants-fall.md
+++ b/.changeset/cozy-plants-fall.md
@@ -1,0 +1,5 @@
+---
+"ghost": patch
+---
+
+Adds a script for generating docker compose files from defined games for local testing

--- a/app/(app)/new/actions/create-server.ts
+++ b/app/(app)/new/actions/create-server.ts
@@ -1,15 +1,13 @@
 "use server";
 
-import crypto from "node:crypto";
-
 import type { Prisma } from "@prisma/client";
-import { humanId } from "human-id";
 import { revalidatePath } from "next/cache";
 import { ulid } from "ulid";
 import { start } from "workflow/api";
 import { z } from "zod";
 
 import { games, validateSettings } from "@/games";
+import { generateJoinPassword, generateRconPassword } from "@/lib/credentials";
 import { prisma } from "@/lib/db";
 import { SNAPSHOT_ENVIRONMENT } from "@/lib/env";
 import { getProviderWithImage } from "@/lib/providers";
@@ -100,10 +98,8 @@ export const createServer = async (
   const settings = validation.data as Record<string, unknown>;
 
   const id = ulid();
-  const rconPassword = crypto.randomBytes(16).toString("hex");
-  const joinPassword = game.usesJoinPassword
-    ? humanId({ adjectiveCount: 0, capitalize: false, separator: "-" })
-    : null;
+  const rconPassword = generateRconPassword();
+  const joinPassword = game.usesJoinPassword ? generateJoinPassword() : null;
 
   const server = await prisma.server.create({
     data: {

--- a/lib/credentials.ts
+++ b/lib/credentials.ts
@@ -1,0 +1,9 @@
+import crypto from "node:crypto";
+
+import { humanId } from "human-id";
+
+export const generateRconPassword = (): string =>
+  crypto.randomBytes(16).toString("hex");
+
+export const generateJoinPassword = (): string =>
+  humanId({ adjectiveCount: 0, capitalize: false, separator: "-" });

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "migrate": "bunx --bun prisma migrate dev && bunx --bun prisma generate",
     "agent:build": "cd agent && bun build --compile --target=bun-linux-x64 ./src/index.ts --outfile ../dist/ghost-agent",
     "agent:dev": "cd agent && bun run src/index.ts",
+    "game:compose": "bun run scripts/generate-compose.ts",
     "codegen": "openapi-typescript https://docs.hetzner.cloud/cloud.spec.json -o lib/hetzner/schema.ts",
     "workflow:ui": "workflow inspect runs --web",
     "check": "ultracite check",

--- a/scripts/generate-compose.ts
+++ b/scripts/generate-compose.ts
@@ -1,0 +1,77 @@
+import crypto from "node:crypto";
+
+import { humanId } from "human-id";
+
+import { games, getGame } from "../games";
+
+const printUsage = (): void => {
+  process.stderr.write(
+    `Usage: bun run game:compose <gameId> [--name <name>] [--timezone <tz>]
+
+Prints a docker-compose YAML to stdout, populated with the game's default
+settings and freshly generated rcon / join passwords. Pipe to a file to use it:
+
+  bun run game:compose minecraft > docker-compose.yml
+  docker compose up
+
+Available games:
+${games.map((g) => `  - ${g.id}`).join("\n")}
+`
+  );
+};
+
+const parseArgs = (
+  argv: readonly string[]
+): { gameId?: string; name?: string; timezone?: string; help: boolean } => {
+  const out: {
+    gameId?: string;
+    name?: string;
+    timezone?: string;
+    help: boolean;
+  } = { help: false };
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") {
+      out.help = true;
+    } else if (arg === "--name") {
+      out.name = argv[i + 1];
+      i += 1;
+    } else if (arg === "--timezone") {
+      out.timezone = argv[i + 1];
+      i += 1;
+    } else if (!out.gameId && arg && !arg.startsWith("-")) {
+      out.gameId = arg;
+    }
+    i += 1;
+  }
+  return out;
+};
+
+const args = parseArgs(process.argv.slice(2));
+
+if (args.help || !args.gameId) {
+  printUsage();
+  process.exit(args.help ? 0 : 1);
+}
+
+const game = getGame(args.gameId);
+if (!game) {
+  process.stderr.write(`Unknown game: ${args.gameId}\n\n`);
+  printUsage();
+  process.exit(1);
+}
+
+const compose = game.buildCompose(
+  {
+    joinPassword: game.usesJoinPassword
+      ? humanId({ adjectiveCount: 0, capitalize: false, separator: "-" })
+      : null,
+    name: args.name ?? `${game.name} Local`,
+    rconPassword: crypto.randomBytes(16).toString("hex"),
+    timezone: args.timezone,
+  },
+  {}
+);
+
+process.stdout.write(compose);

--- a/scripts/generate-compose.ts
+++ b/scripts/generate-compose.ts
@@ -1,12 +1,9 @@
-import crypto from "node:crypto";
-
-import { humanId } from "human-id";
-
-import { games, getGame } from "../games";
+import { games, getDefaults, getGame, missingRequiredFields } from "../games";
+import { generateJoinPassword, generateRconPassword } from "../lib/credentials";
 
 const printUsage = (): void => {
   process.stderr.write(
-    `Usage: bun run game:compose <gameId> [--name <name>] [--timezone <tz>]
+    `Usage: bun run game:compose <gameId> [--name <name>] [--timezone <tz>] [--memory <gb>]
 
 Prints a docker-compose YAML to stdout, populated with the game's default
 settings and freshly generated rcon / join passwords. Pipe to a file to use it:
@@ -14,33 +11,61 @@ settings and freshly generated rcon / join passwords. Pipe to a file to use it:
   bun run game:compose minecraft > docker-compose.yml
   docker compose up
 
+Options:
+  --name <name>   Server name (default: "<Game> Local")
+  --timezone <tz> Container timezone (default: UTC)
+  --memory <gb>   Machine memory in GB; games size heaps/caches from it
+  --help, -h      Show this help
+
 Available games:
 ${games.map((g) => `  - ${g.id}`).join("\n")}
 `
   );
 };
 
-const parseArgs = (
-  argv: readonly string[]
-): { gameId?: string; name?: string; timezone?: string; help: boolean } => {
-  const out: {
-    gameId?: string;
-    name?: string;
-    timezone?: string;
-    help: boolean;
-  } = { help: false };
+const fail = (message: string): never => {
+  process.stderr.write(`${message}\n\n`);
+  printUsage();
+  process.exit(1);
+};
+
+interface ParsedArgs {
+  gameId?: string;
+  name?: string;
+  timezone?: string;
+  memoryGb?: number;
+  help: boolean;
+}
+
+const parseArgs = (argv: readonly string[]): ParsedArgs => {
+  const out: ParsedArgs = { help: false };
   let i = 0;
   while (i < argv.length) {
     const arg = argv[i];
     if (arg === "--help" || arg === "-h") {
       out.help = true;
-    } else if (arg === "--name") {
-      out.name = argv[i + 1];
+    } else if (arg === "--name" || arg === "--timezone" || arg === "--memory") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        fail(`Missing value for ${arg}`);
+      }
+      if (arg === "--name") {
+        out.name = value;
+      } else if (arg === "--timezone") {
+        out.timezone = value;
+      } else {
+        const memoryGb = Number(value);
+        if (!Number.isFinite(memoryGb) || memoryGb <= 0) {
+          fail(`Invalid value for --memory: ${value}`);
+        }
+        out.memoryGb = memoryGb;
+      }
       i += 1;
-    } else if (arg === "--timezone") {
-      out.timezone = argv[i + 1];
-      i += 1;
-    } else if (!out.gameId && arg && !arg.startsWith("-")) {
+    } else if (arg?.startsWith("-")) {
+      fail(`Unknown option: ${arg}`);
+    } else if (out.gameId) {
+      fail(`Unexpected argument: ${arg}`);
+    } else {
       out.gameId = arg;
     }
     i += 1;
@@ -55,20 +80,29 @@ if (args.help || !args.gameId) {
   process.exit(args.help ? 0 : 1);
 }
 
-const game = getGame(args.gameId);
-if (!game) {
-  process.stderr.write(`Unknown game: ${args.gameId}\n\n`);
-  printUsage();
-  process.exit(1);
+const game = getGame(args.gameId) ?? fail(`Unknown game: ${args.gameId}`);
+
+// The compose is built from default settings, so required fields with no
+// default (e.g. Don't Starve Together's cluster token) come out empty: the
+// YAML is valid but the server won't boot until they are filled in.
+const missing = missingRequiredFields(
+  game.settings,
+  getDefaults(game.settings)
+);
+if (missing.length > 0) {
+  process.stderr.write(
+    `Warning: ${game.name} has required settings with no default (${missing.join(
+      ", "
+    )}); fill them in before running the generated compose file.\n`
+  );
 }
 
 const compose = game.buildCompose(
   {
-    joinPassword: game.usesJoinPassword
-      ? humanId({ adjectiveCount: 0, capitalize: false, separator: "-" })
-      : null,
+    joinPassword: game.usesJoinPassword ? generateJoinPassword() : null,
+    memoryGb: args.memoryGb ?? null,
     name: args.name ?? `${game.name} Local`,
-    rconPassword: crypto.randomBytes(16).toString("hex"),
+    rconPassword: generateRconPassword(),
     timezone: args.timezone,
   },
   {}


### PR DESCRIPTION
## Description

While working on https://github.com/haydenbleasel/ghost/pull/55 I needed a quick and dirty way for checking that the docker compose files that were being created were valid, and could be used for provisioning, without actually needing all the various environment variables and services that the project depends on. I assume that as long as a `game.buildCompose` creates a valid compose file, the rest of the provisioning will "just work"

Below is an example output
```
$ bun run scripts/generate-compose.ts minecraft
services:
  minecraft:
    image: itzg/minecraft-server:latest
    container_name: ghost-game
    ports:
      - "25565:25565"
    environment:
      EULA: "TRUE"
      SERVER_NAME: "Minecraft Local"
      MOTD: "Minecraft Local - Powered by Ghost"
      DIFFICULTY: "normal"
      MODE: "survival"
      MEMORY: "6G"
      TZ: "UTC"
      ENABLE_RCON: "true"
      RCON_PASSWORD: "de4e68de197c5dbea93e4b737a1313ec"
      OVERRIDE_SERVER_PROPERTIES: "true"
      ENABLE_COMMAND_BLOCK: "true"
      SPAWN_PROTECTION: "0"
      MAX_PLAYERS: "20"
      ALLOW_NETHER: "true"
      ONLINE_MODE: "true"
      PVP: "true"
      VIEW_DISTANCE: "10"
    volumes:
      - /var/lib/ghost/game/data:/data
    restart: unless-stopped
 ```

I was unable to get some tests passing locally due to missing environment variables. These tests also fail on forked versions of main.

## Related Issues

N/A

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [ ] New and existing tests pass locally with my changes.

## Screenshots (if applicable)

N/A

## Additional Notes

N/A
